### PR TITLE
fix: make mobile menu fullscreen

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -26,6 +26,10 @@ function Header() {
   const viewResume = resumeSection.display;
   const viewEducation = educationInfo.display;
 
+  const handleMenuToggle = e => {
+    document.body.style.overflow = e.target.checked ? "hidden" : "auto";
+  };
+
   return (
     <Headroom>
       <header className={isDark ? "dark-menu header" : "header"}>
@@ -34,7 +38,12 @@ function Header() {
           <span className="logo-name">{greeting.username}</span>
           <span className="grey-color">/&gt;</span>
         </a>
-        <input className="menu-btn" type="checkbox" id="menu-btn" />
+        <input
+          className="menu-btn"
+          type="checkbox"
+          id="menu-btn"
+          onChange={handleMenuToggle}
+        />
         <label
           className="menu-icon"
           htmlFor="menu-btn"

--- a/src/components/header/Header.scss
+++ b/src/components/header/Header.scss
@@ -58,6 +58,8 @@
   text-decoration: none;
   margin-top: 10px;
   line-height: normal;
+  position: relative;
+  z-index: 1001;
 }
 
 .header .logo-name {
@@ -85,6 +87,7 @@
   padding: 28px 20px;
   position: relative;
   user-select: none;
+  z-index: 1001;
 }
 
 .header .menu-icon .navicon {
@@ -137,7 +140,18 @@
 }
 
 .header .menu-btn:checked ~ .menu {
-  max-height: 486px;
+  max-height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  background-color: $lightBackground1;
+  display: flex;
+  flex-direction: column;
+  padding-top: 80px;
+  box-sizing: border-box;
+  z-index: 1000;
 }
 
 .header .menu-btn:checked ~ .menu-icon .navicon {


### PR DESCRIPTION
## Summary
- expand mobile menu to cover entire viewport
- disable body scrolling while menu open and restore on close
- animate mobile menu opening while in fullscreen overlay
- layer site logo above fullscreen menu so branding stays visible
- pad fullscreen menu so options start below the logo for unobstructed view

## Testing
- `npm run check-format`
- `npm test -- --watchAll=false` *(fails: Could not load the "sharp" module)*

------
https://chatgpt.com/codex/tasks/task_e_68941f7d1b788324bdfc3625485be9dd